### PR TITLE
Add support for custom wordlists (via -wordfile param)

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,20 +3,23 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/tteeoo/neotype/game"
-	"github.com/tteeoo/neotype/util"
-	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/tteeoo/neotype/game"
+	"github.com/tteeoo/neotype/util"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var version = flag.Bool("version", false, "Print version information and exit")
 var words = flag.Int("words", 0, "The number of words to test with")
+var wordFile = flag.String("wordfile", "words.txt", "The name of the wordlist in the data directory")
 
 func main() {
 
@@ -46,8 +49,9 @@ func main() {
 	util.DieIf(err, "NeoType: error: cannot get terminal size: %s\n", err)
 
 	// Generate words
-	dictionaryB, err := ioutil.ReadFile(shareDir + "/words.txt")
-	util.DieIf(err, "NeoType: error: cannot read file '%s/words.txt': %s\n", shareDir, err)
+	wordFilePath := filepath.Join(shareDir, *wordFile)
+	dictionaryB, err := ioutil.ReadFile(wordFilePath)
+	util.DieIf(err, "NeoType: error: cannot read file '%s': %s\n", wordFilePath, err)
 	dictionary := strings.Split(string(dictionaryB), "\n")
 	rand.Seed(time.Now().Unix())
 	var chosen []string

--- a/util/util.go
+++ b/util/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 )
 
 // DieIf printfs and exits if err != nil.
@@ -17,27 +18,30 @@ func DieIf(err error, format string, a ...interface{}) {
 // ResolveShare checks multiple environment variables, finds the location of the data directory,
 // ensures it exists and it is accessable, then returns the path.
 func ResolveShare() (string, error) {
-	share := os.Getenv("NEOTYPE_DATA")
-	if share == "" {
-		share = os.Getenv("XDG_DATA_HOME")
-		if share == "" {
-			user, err := user.Current()
-			if err != nil {
-				return "", err
-			}
-			share = user.HomeDir + "/.local/share/neotype"
-		} else {
-			share += "/neotype"
+	neotypeData := os.Getenv("NEOTYPE_DATA")
+	xdgDataHome := os.Getenv("XDG_DATA_HOME")
+
+	var share string
+	if neotypeData != "" {
+		share = neotypeData
+	} else if xdgDataHome != "" {
+		share = filepath.Join(xdgDataHome, "/neotype")
+	} else {
+		user, err := user.Current()
+		if err != nil {
+			return "", err
 		}
+		share = filepath.Join(user.HomeDir, "/.local/share/neotype")
 	}
+
 	_, err := os.Stat(share)
 	if os.IsNotExist(err) {
-		err = os.Mkdir(share, 0755)
-		if err != nil {
+		if err = os.Mkdir(share, 0755); err != nil {
 			return "", err
 		}
 	} else if err != nil {
 		return "", err
 	}
+
 	return share, nil
 }


### PR DESCRIPTION
This PR adds support for optionally setting alertnate wordlists. The default behavior is exactly the same as it was before, but now you can have multiple wordlists in your share directory, and easily toggle between them.

```
  -wordfile string
        The name of the wordlist in the data directory (default "words.txt")
```

Example: `neotype -wordfile words-complex.txt`.

I also:
Simplified `ResolveShare`, to make the logic there a bit easier to understand (in my opinion).
Used `filepath.Join` over `+` where applicable, which should help in the case that a wordlist is located in a subdirectory.