### PR TITLE
Add support for absolute or relative wordfile paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func main() {
 
 	// Get word file
 	wordFilePath, err := util.ResolveFilePath(*wordFile)
-	util.DieIf(err, "NeoType: Error: cannot find word file: %s\n", err)
+	util.DieIf(err, "NeoType: Error: Cannot find word file: %s\n", err)
 
 	// Get terminal dimensions
 	w, h, err := terminal.GetSize(0)
@@ -100,7 +100,7 @@ func main() {
 	fmt.Printf("Raw: %d\n", g.Raw())
 
 	err = exec.Command("stty", "-F", "/dev/tty", "echo").Run()
-	util.DieIf(err, "NeoType: Wrror: Cannot run command \"stty -F /dev/tty echo\": %s\n", err)
+	util.DieIf(err, "NeoType: Error: Cannot run command \"stty -F /dev/tty echo\": %s\n", err)
 
 	os.Exit(0)
 }

--- a/main.go
+++ b/main.go
@@ -33,10 +33,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Get data directory
-	shareDirs := util.GetSharePaths()
-	wordFilePath, err := util.ResolveFilePath(*wordFile, shareDirs...)
-	util.DieIf(err, "NeoType: error: cannot find data directory: %s\n", err)
+	// Get word file
+	wordFilePath, err := util.ResolveFilePath(*wordFile)
+	util.DieIf(err, "NeoType: error: cannot find word file: %s\n", err)
 
 	// Get terminal dimensions
 	w, h, err := terminal.GetSize(0)

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -35,7 +34,8 @@ func main() {
 	}
 
 	// Get data directory
-	shareDir, err := util.ResolveShare()
+	shareDirs := util.GetSharePaths()
+	wordFilePath, err := util.ResolveFilePath(*wordFile, shareDirs...)
 	util.DieIf(err, "NeoType: error: cannot find data directory: %s\n", err)
 
 	// Get terminal dimensions
@@ -43,7 +43,6 @@ func main() {
 	util.DieIf(err, "NeoType: error: cannot get terminal size: %s\n", err)
 
 	// Generate words
-	wordFilePath := filepath.Join(shareDir, *wordFile)
 	dictionaryB, err := ioutil.ReadFile(wordFilePath)
 	util.DieIf(err, "NeoType: error: cannot read file \"%s\": %s\n", wordFilePath, err)
 	dictionary := strings.Split(string(dictionaryB), "\n")
@@ -103,7 +102,6 @@ func main() {
 
 	err = exec.Command("stty", "-F", "/dev/tty", "echo").Run()
 	util.DieIf(err, "NeoType: error: cannot run command \"stty -F /dev/tty echo\": %s\n", err)
-
 
 	os.Exit(0)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -1,10 +1,13 @@
 package util
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
+	"path"
 	"path/filepath"
+	"strings"
 )
 
 // DieIf printfs and exits if err != nil.
@@ -15,33 +18,99 @@ func DieIf(err error, format string, a ...interface{}) {
 	}
 }
 
-// ResolveShare checks multiple environment variables, finds the location of the data directory,
-// ensures it exists and it is accessable, then returns the path.
-func ResolveShare() (string, error) {
-	neotypeData := os.Getenv("NEOTYPE_DATA")
-	xdgDataHome := os.Getenv("XDG_DATA_HOME")
+// createDirectory will create a directory and set permissions,
+// if the directory does not already exist. It returns true
+// if a directory was created, and false if it was not.
+func createDirectory(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		if err = os.Mkdir(path, 0755); err != nil {
+			return false, err
+		}
+		return true, nil
+	} else if err != nil {
+		return false, err
+	}
+	return false, nil
+}
 
-	var share string
+func fileExists(filename string) (bool, error) {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false, nil
+	} else if err != nil {
+		return false, err
+	}
+	return !info.IsDir(), nil
+}
+
+// appendUnique will append any unique string to the slice.
+// If the string is already in the slice, the slice is returned unchanged.
+func appendUnique(slice []string, str string) []string {
+	for _, s := range slice {
+		if s == str {
+			return slice
+		}
+	}
+	return append(slice, str)
+}
+
+// GetSharePaths returns an array of all unique defined
+// locations that may contain wordlist data.
+func GetSharePaths() (shares []string) {
+	workingDir, err := os.Getwd()
+	if err == nil {
+		shares = append(shares, workingDir)
+	}
+
+	neotypeData := os.Getenv("NEOTYPE_DATA")
 	if neotypeData != "" {
-		share = neotypeData
-	} else if xdgDataHome != "" {
-		share = filepath.Join(xdgDataHome, "/neotype")
-	} else {
-		user, err := user.Current()
+		shares = appendUnique(shares, neotypeData)
+	}
+
+	xdgDataHome := os.Getenv("XDG_DATA_HOME")
+	if xdgDataHome != "" {
+		shares = appendUnique(shares, filepath.Join(xdgDataHome, "/neotype"))
+	}
+
+	user, err := user.Current()
+	if err == nil {
+		shares = appendUnique(shares, filepath.Join(user.HomeDir, "/.local/share/neotype"))
+	}
+
+	return shares
+}
+
+// ResolveFilePath checks multiple paths for the given wordlist,
+// then returns the path if available. It returns an error if more
+// than one potential wordlist is found.
+func ResolveFilePath(filename string, shares ...string) (string, error) {
+	matchedFiles := []string{}
+
+	for _, d := range shares {
+		created, err := createDirectory(d)
 		if err != nil {
 			return "", err
 		}
-		share = filepath.Join(user.HomeDir, "/.local/share/neotype")
-	}
-
-	_, err := os.Stat(share)
-	if os.IsNotExist(err) {
-		if err = os.Mkdir(share, 0755); err != nil {
-			return "", err
+		if !created {
+			filepath := path.Join(d, filename)
+			matched, err := fileExists(filepath)
+			if err != nil {
+				return "", err
+			}
+			if matched {
+				matchedFiles = append(matchedFiles, filepath)
+			}
 		}
-	} else if err != nil {
-		return "", err
 	}
 
-	return share, nil
+	if len(matchedFiles) == 1 {
+		return matchedFiles[0], nil
+	}
+
+	if len(matchedFiles) > 1 {
+		return "", errors.New("Matched multiple files: " + strings.Join(matchedFiles, ", "))
+	}
+
+	return "", errors.New("Wordfile was not found in any of these locations: " + strings.Join(shares, ", "))
 }

--- a/util/util.go
+++ b/util/util.go
@@ -65,17 +65,12 @@ func getSharePath() (string, error) {
 // ResolveFilePath checks the working directory and the share
 // for the given file, then returns the path if available.
 func ResolveFilePath(filename string) (string, error) {
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	workingDirFile := path.Join(workingDir, filename)
-	matched, err := fileExists(workingDirFile)
+	matched, err := fileExists(filename)
 	if err != nil {
 		return "", err
 	}
 	if matched {
-		return workingDirFile, nil
+		return filename, nil
 	}
 
 	sharePath, err := getSharePath()


### PR DESCRIPTION
Closes #4 

This PR changes the behavior of wordlist discovery.

**Previously:** NeoType would find the first defined share and look for wordlists at that location.

**With this change:**
- NeoType will look for a file at the direct path passed to `wordfile`. e.g.:
  - `words.txt` or `./words.txt` will resolve a `words.txt` file in the working directory.
  - `folder/words.txt` or `./folder/words.txt` will resolve a `words.txt` file relative to the working directory.
  - `/folder/words.txt` resolves the absolute filepath `/folder/words.txt`.
  - `~/words.txt` will be converted to the absolute filepath `/home/user/words.txt`.
- If a file is not resolved, NeoType will find the user's share location via the same logic as was previously used.
- If a share is resolved, NeoType will look for a file at the share joined with the path passed to `wordfile`. e.g.:
  - `words.txt` or `./words.txt` will resolve a `words.txt` file in the share.
  - `folder/words.txt` or `./folder/words.txt` will resolve a `words.txt` file relative to the share.
- If no files have been found, an error is thrown.